### PR TITLE
Update whole-fungible.json

### DIFF
--- a/artifacts/base/whole-fungible/latest/whole-fungible.json
+++ b/artifacts/base/whole-fungible/latest/whole-fungible.json
@@ -47,7 +47,7 @@
     ],
     "incompatibleWithSymbols": [
       {
-        "id": "d5807a8e-879b-4885-95fa-f09ba2a22172",
+        "id": "6e3501dc-5800-4c71-b59e-ad11418a998c",
         "type": "BEHAVIOR",
         "visual": "<i>~d</i>",
         "tooling": "~d",


### PR DESCRIPTION
Whole Fungible base type should be listed as incompatible with Divisibility; but it's currently incompatible with Indivisibility.